### PR TITLE
chore(ci): update release workflow configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 jobs:
   prepare-artifacts:
@@ -15,22 +15,22 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             rust: stable
-            suffix: ""
+            suffix: ''
             archive_ext: zip
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             rust: stable
-            suffix: ""
+            suffix: ''
             archive_ext: zip
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             rust: stable
-            suffix: ""
+            suffix: ''
             archive_ext: tar.xz
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             rust: stable
-            suffix: ""
+            suffix: ''
             archive_ext: tar.xz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -110,7 +110,7 @@ jobs:
       - name: Extract version
         id: extract-version
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> ${GITHUB_OUTPUT}
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
       - name: Download convco
         run: |
@@ -142,8 +142,8 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: "*.zip,*.tar.xz"
-          bodyFile: "CHANGELOG.md"
+          artifacts: '*.zip,*.tar.xz'
+          bodyFile: 'CHANGELOG.md'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   homebrew:
@@ -156,9 +156,9 @@ jobs:
       - name: Extract version
         id: extract-version
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> ${GITHUB_OUTPUT}
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@v4
         if: ${{ !contains(github.ref, '-') }} # skip prereleases
         with:
           formula-name: podfeed


### PR DESCRIPTION
Update the GitHub Actions release workflow to use modern macOS runners and fix shell quoting.

Switches from macos-latest to macos-15-intel for x86_64 builds and updates the Homebrew formula bump action to v4. Also standardizes on single quotes in YAML and adds proper quoting for GITHUB_OUTPUT variable assignments.