### PR TITLE
Bump MSRV to 1.95 and adopt std::fs::exists

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        rust: [1.88.0, beta, nightly]
+        rust: [1.95.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "podfeed"
 version = "0.3.2"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "A podcast feed-generator."
 readme = "README.md"
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=podfeed
-MSRV=1.88
+MSRV=1.95
 
 get_rust_version() {
   local array=($(rustc --version));

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -107,8 +107,8 @@ pub fn convert_channel<P: AsRef<Path>>(
     // Resize channel image to fill 1400x1400 and add the "1400x1400" suffix.
     let resized_image_filepath = get_resized_image_filepath(image_filepath.as_ref(), TARGET_SIZE);
 
-    // Resize the channel image if the resized image does not already exists.
-    if !resized_image_filepath.exists() {
+    // Resize the channel image if the resized image does not already exist.
+    if !std::fs::exists(&resized_image_filepath)? {
         resize_image_to_fill(
             image_filepath.as_ref(),
             resized_image_filepath.as_ref(),
@@ -155,8 +155,8 @@ pub fn convert_episode<P: AsRef<Path>>(
     // Resize episode image to fill 1400x1400 and add the "1400x1400" suffix.
     let resized_image_filepath = get_resized_image_filepath(image_filepath.as_ref(), TARGET_SIZE);
 
-    // Resize the channel image if the resized image does not already exists.
-    if !resized_image_filepath.exists() {
+    // Resize the episode image if the resized image does not already exist.
+    if !std::fs::exists(&resized_image_filepath)? {
         resize_image_to_fill(
             image_filepath.as_ref(),
             resized_image_filepath.as_ref(),


### PR DESCRIPTION
Bumps the minimum supported Rust version from 1.88 to 1.95 and replaces `Path::exists()` with `std::fs::exists()` (stabilized in 1.81). The old method silently returns `false` on permission errors or other I/O failures; the new one returns `Result<bool>` and propagates errors via `?`.