### PR TITLE
feat(ci): remove windows builds from the ci

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -84,10 +84,6 @@ jobs:
             target: aarch64-apple-darwin
             type: unix
             toolchain: stable
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            type: windows
-            toolchain: stable
     steps:
       - name: Rust install
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,6 @@ jobs:
             rust: stable
             suffix: ''
             archive_ext: tar.xz
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            rust: stable
-            suffix: .exe
-            archive_ext: zip
     steps:
       - name: Rust install
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -72,17 +67,6 @@ jobs:
         run: |
           cp "target/${TARGET}/release/${REPO_NAME}" .
           zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
-
-      - name: Compress to zip (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-          SUFFIX: ${{ matrix.suffix }}
-          TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: |
-          Copy-Item "target/${env:TARGET}/release/${env:REPO_NAME}${env:SUFFIX}" .
-          Compress-Archive "${env:REPO_NAME}${env:SUFFIX}" "${env:REPO_NAME}-${env:TARGET}.${env:ARCHIVE_EXT}"
 
       - name: Compress to tar.xz (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
@@ -155,10 +139,6 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-x86_64-pc-windows-msvc.zip
-
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There has been no evidence that anyone uses the windows builds although they complexity and cost. Removing.
