### PR TITLE
ci: apply github-actions-playbook topic docs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,11 +2,17 @@
 # https://nexte.st/docs/configuration/
 
 [profile.default]
+# Number of retries for failing tests (0 = no retries)
 retries = 0
+# Use all available CPUs
 test-threads = "num-cpus"
+# Continue running other tests when one fails
 fail-fast = false
+# Warn about slow tests after 60s, terminate after 2 periods (120s)
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [profile.ci]
+# Retry flaky tests in CI
 retries = 2
+# Stop on first failure in CI to get faster feedback
 fail-fast = true

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -48,7 +48,7 @@ jobs:
             tar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny
           mv cargo-deny ~/.cargo/bin/
-          cargo deny check
+          cargo deny check --locked
 
       - name: Security – cargo pants
         run: |

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Test pre-releases on a larger scope (platforms & versions) to avoid bad surprises.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-other-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
 
 name: 'CI: Compatibility Matrix'
 on:
@@ -17,14 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-versions:
+  test-all-versions:
     name: ubuntu-latest (${{ matrix.rust }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
-        rust: [1.95.0, beta, nightly]
+        rust: ['1.95.0', beta, nightly]
 
     steps:
       - name: Install Rust
@@ -38,95 +38,78 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache crates
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
+
+      - name: Build (dev)
+        run: cargo build --locked
+
+      - name: Build (release)
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
         with:
           tool: cargo-nextest@0.9.133
 
-      - name: Build (dev)
-        run: cargo build --all-features
-
-      - name: Build (release)
-        run: cargo build --all-features --release
-
       - name: Test
         run: ./ci/test_full.sh
 
-  test-other-platforms:
-    name: ${{ matrix.os }} (stable)
+  test-all-platforms:
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            type: unix
-            toolchain: stable
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            type: unix
-            toolchain: stable
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            type: unix
-            toolchain: stable
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: aarch64-apple-darwin
+            os: macos-latest
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           targets: ${{ matrix.target }}
-          components: rustfmt, clippy
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Cache crates
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Build (dev)
+        run: cargo build --locked
+
+      - name: Build (release)
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
         with:
           tool: cargo-nextest@0.9.133
-
-      - name: Build (dev)
-        run: cargo build --all-features
-
-      - name: Build (release)
-        run: cargo build --all-features --release
 
       - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
 
       - name: Quality – convco check
         run: |
@@ -72,16 +72,16 @@ jobs:
           ./convco check -c .convco
           rm convco
 
+      - name: Build (dev)
+        run: cargo build --locked
+
+      - name: Build (release)
+        run: cargo build --locked --release
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
         with:
           tool: cargo-nextest@0.9.133
-
-      - name: Build (dev)
-        run: cargo build --all-features
-
-      - name: Build (release)
-        run: cargo build --all-features --release
 
       - name: Test
         run: ./ci/test_full.sh
@@ -95,10 +95,12 @@ jobs:
       cargo_lock: ${{ steps.filter.outputs.cargo_lock }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - id: filter
+      - name: Filter changed paths
+        id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 # Local:
 #   act push -W .github/workflows/release.yml -j prepare-artifacts
 #   act push -W .github/workflows/release.yml -j release
+#   act push -W .github/workflows/release.yml -j homebrew
 
 name: Release
 on:
@@ -18,90 +19,114 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: Build artifacts
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write           # build provenance
+      attestations: write
+    defaults:
+      run:
+        shell: bash
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            rust: stable
-            suffix: ''
-            archive_ext: zip
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            rust: stable
-            suffix: ''
-            archive_ext: zip
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            rust: stable
-            suffix: ''
-            archive_ext: tar.xz
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            rust: stable
-            suffix: ''
-            archive_ext: tar.xz
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.xz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            archive: tar.xz
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+            archive: tar.xz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.xz
     steps:
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-          components: rustfmt, clippy
-
-      - name: Install musl-tools (Linux)
-        if: contains(matrix.target, '-musl')
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Install musl-tools (Linux)
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Build (release)
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}"
+        run: cargo build --locked --release --target "${TARGET}"
 
-      - name: Package – compress (zip)
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' }}
+      - name: Stage binary and archive
         env:
-          REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+          ARCHIVE_FORMAT: ${{ matrix.archive }}
+          TAG: ${{ github.ref_name }}
+          BIN: podfeed
         run: |
-          cp "target/${TARGET}/release/${REPO_NAME}" .
-          zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
+          set -euo pipefail
+          SRC="target/${TARGET}/release/${BIN}"
 
-      - name: Package – compress (tar.xz)
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-          TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: |
-          cp "target/${TARGET}/release/${REPO_NAME}" .
-          tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
+          # Standalone binary: <bin>-<target>
+          STANDALONE="${BIN}-${TARGET}"
+          cp "${SRC}" "${STANDALONE}"
+
+          # Archive: <bin>-<tag>-<target>.{tar.xz,zip} containing the binary,
+          # README, and LICENSE.
+          PKG_DIR="${BIN}-${TAG}-${TARGET}"
+          mkdir "${PKG_DIR}"
+          cp "${SRC}" "${PKG_DIR}/"
+          cp README.md LICENSE* "${PKG_DIR}/" 2>/dev/null || true
+
+          if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
+            ARCHIVE_FILE="${PKG_DIR}.zip"
+            7z a "${ARCHIVE_FILE}" "${PKG_DIR}" >/dev/null
+          else
+            ARCHIVE_FILE="${PKG_DIR}.tar.xz"
+            tar -cJf "${ARCHIVE_FILE}" "${PKG_DIR}"
+          fi
+
+          echo "STANDALONE=${STANDALONE}" >> "${GITHUB_ENV}"
+          echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >> "${GITHUB_ENV}"
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            ${{ env.STANDALONE }}
+            ${{ env.ARCHIVE_FILE }}
+
+      - name: Upload – standalone
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.STANDALONE }}
+          path: ${{ env.STANDALONE }}
+          retention-days: 1
 
       - name: Upload – archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
-          path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          name: ${{ env.ARCHIVE_FILE }}
+          path: ${{ env.ARCHIVE_FILE }}
           retention-days: 1
 
   release:
     name: Publish release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: write           # gh release create
     needs:
       - prepare-artifacts
     steps:
@@ -112,14 +137,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Extract version
-        id: extract-version
-        run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
-
       - name: Install convco
         run: |
-          git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
@@ -129,22 +148,12 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - name: Download – archive (x86_64-unknown-linux-musl)
+      - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-x86_64-unknown-linux-musl.tar.xz
-      - name: Download – archive (aarch64-unknown-linux-musl)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-aarch64-unknown-linux-musl.tar.xz
-      - name: Download – archive (aarch64-apple-darwin)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
-      - name: Download – archive (x86_64-apple-darwin)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
+          path: artifacts
+          merge-multiple: true
+
       - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,12 +162,7 @@ jobs:
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
-            ./*.zip ./*.tar.xz
-
-      - name: Attest provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: '*.zip,*.tar.xz'
+            ./artifacts/*
 
   homebrew:
     name: Bump Homebrew formula
@@ -183,7 +187,8 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+      - name: Bump Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         if: '!contains(github.ref, ''-'')' # skip prereleases
         with:
           formula-name: podfeed

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -38,28 +38,39 @@ fi
 set -x
 
 # test the default
-cargo build
-cargo nextest run $NEXTEST_PROFILE
+cargo build --locked
+cargo nextest run --locked $NEXTEST_PROFILE
 
 # test `no_std`
-cargo build --no-default-features
-cargo nextest run $NEXTEST_PROFILE --no-default-features
+cargo build --locked --no-default-features
+cargo nextest run --locked $NEXTEST_PROFILE --no-default-features
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
-  # cargo build --no-default-features --features="std $feature"
-  # cargo nextest run $NEXTEST_PROFILE --no-default-features --features="std $feature"
+  # cargo build --locked --no-default-features --features="std $feature"
+  # cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="std $feature"
 
-  cargo build --no-default-features --features="$feature"
-  cargo nextest run $NEXTEST_PROFILE --no-default-features --features="$feature"
+  cargo build --locked --no-default-features --features="$feature"
+  cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
-# cargo build --features="std ${FEATURES[*]}"
-# cargo nextest run $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
+# cargo build --locked --features="std ${FEATURES[*]}"
+# cargo nextest run --locked $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
 
-cargo build --features="${FEATURES[*]}"
-cargo nextest run $NEXTEST_PROFILE --features="${FEATURES[*]}"
+cargo build --locked --features="${FEATURES[*]}"
+cargo nextest run --locked $NEXTEST_PROFILE --features="${FEATURES[*]}"
 
 # doc tests (not supported by nextest)
-cargo test --doc
+cargo test --locked --doc
+
+# CLI smoke test (release binary). CARGO_BUILD_TARGET (set in the compat
+# matrix) redirects output to target/<target>/release; Git Bash on Windows
+# reports OSTYPE=msys.
+cargo build --locked --release
+
+BIN="target/${CARGO_BUILD_TARGET:+${CARGO_BUILD_TARGET}/}release/podfeed"
+case "${OSTYPE:-}" in
+  msys*|cygwin*) BIN="${BIN}.exe" ;;
+esac
+"${BIN}" --help

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
+  "automergeStrategy": "merge-commit",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
@@ -22,7 +23,9 @@
     },
     {
       "description": "Group all patch updates into one PR",
-      "matchUpdateTypes": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "patch updates",
       "automerge": true
     },

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -166,7 +166,10 @@ pub fn convert_episode<P: AsRef<Path>>(
 
     let target = rss::episode::Episode {
         guid: source.guid.clone(),
-        pub_date: format!("{}", &source.pub_date().format("%a, %d %b %Y %H:%M:%S %z")),
+        pub_date: source
+            .pub_date()
+            .format("%a, %d %b %Y %H:%M:%S %z")
+            .to_string(),
         title: source.title.clone(),
         link: source.link.clone(),
         description: source.description.clone(),


### PR DESCRIPTION
Continues the playbook adoption started in #32 by applying the
Testing, Renovate, and Release topic docs on top of the Conventions
and Hardening baseline already on main.

The substantive changes: every cargo invocation now passes --locked
so a stale lockfile fails CI loudly instead of silently regenerating
between the test and release jobs; the compat matrix tests linux-musl
instead of linux-gnu so it matches what the release matrix actually
ships; build provenance moves into prepare-artifacts so attestation
covers the real build outputs (not re-downloaded copies); release
artifacts use tar.xz on all unix targets; renovate gets
automergeStrategy: merge-commit so platform automerge doesn't
silently no-op against the ruleset.

A handful of canonical renames from conventions.md
(test-versions -> test-all-versions, Build artifacts ->
${{ matrix.target }}, etc.) round it out. Benchmarks and coverage
docs don't apply — both are opt-in and the repo has no existing
infra for either.

Verified: zizmor and poutine both clean.