### PR TITLE
ci: align matrix-job naming with playbook conventions

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Test pre-releases on a larger scope (platforms & versions) to avoid bad surprises.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-rust-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-platforms
 
 name: 'CI: Compatibility Matrix'
 on:
@@ -17,8 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-versions:
-    name: ubuntu-latest (${{ matrix.rust }})
+  test-rust-versions:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -60,8 +59,7 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-all-platforms:
-    name: ${{ matrix.target }}
+  test-platforms:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -23,14 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Checkout
@@ -52,7 +49,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Quality – cargo fmt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
Sync the matrix-job conventions from the github-actions-playbook reference:
let GitHub render check names as `<job-key> (<matrix-values>)` instead of
overriding them with custom `name:` templates that hide the job key.

In ci-compatibility-matrix, the generic keys `test-all-versions` and
`test-all-platforms` are renamed to `test-rust-versions` and
`test-platforms` so the key itself describes the dimension being varied.
The `name:` overrides are dropped on both matrix jobs and on
release.yml's `prepare-artifacts`.

ci-essentials' `test` job had a single-value `rust: [stable]` matrix —
collapsed to an inline `stable` in the toolchain spec and the cache key.
No `needs:` references pointed at the renamed keys.