### PR TITLE
chore(ci): further hardening

### DIFF
--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -7,6 +7,5 @@ skip:
       - pkg:githubactions/dorny/paths-filter
       - pkg:githubactions/zizmorcore/zizmor-action
       - pkg:githubactions/boostsecurityio/poutine-action
-      - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/renovatebot/github-action
       - pkg:githubactions/taiki-e/install-action

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Security – cargo pants
         run: |
-          cargo install --locked cargo-pants || true
+          cargo install --locked cargo-pants || command -v cargo-pants
           cargo pants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      id-token: write           # build provenance
+      id-token: write # build provenance
       attestations: write
     defaults:
       run:
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      contents: write           # gh release create
+      contents: write # gh release create
     needs:
       - prepare-artifacts
     steps:
@@ -180,6 +180,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: graelo
           repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Extract version
         id: extract-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ contains(github.ref, '-') }}
         run: |
           gh release create "${TAG_NAME}" \
+            --prerelease="${IS_PRERELEASE}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
             ./artifacts/*
@@ -171,6 +173,13 @@ jobs:
       contents: read
     needs:
       - release
+    if: ${{ !contains(github.ref, '-') }} # skip prereleases (-rc, -alpha, -beta, ...)
+    env:
+      TAP_REPO: graelo/homebrew-tap
+      FORMULA_NAME: podfeed
+      BOT_NAME: 'graelo-ci-bot[bot]'
+      BOT_USER_ID: '274240725'
+      REPO_URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -183,23 +192,34 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Extract version
-        id: extract-version
+      - name: Configure Homebrew, git, and gh for the bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
+          # Linuxbrew is preinstalled on ubuntu-latest; put it on PATH for later steps.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "${GITHUB_PATH}"
+
+          # Tap our formula so `brew bump-formula-pr` can locate it by name.
+          brew tap "${TAP_REPO}"
+
+          # Configure git to push with the app token, and set the bot identity
+          # so the commit is attributed to ${BOT_NAME}.
+          gh auth setup-git
+          git config --global user.name  "${BOT_NAME}"
+          git config --global user.email "${BOT_USER_ID}+${BOT_NAME}@users.noreply.github.com"
 
       - name: Bump Homebrew formula
-        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
-        if: '!contains(github.ref, ''-'')' # skip prereleases
-        with:
-          formula-name: podfeed
-          homebrew-tap: graelo/homebrew-tap
-          push-to: graelo/homebrew-tap
-          create-pullrequest: true
-          download-url: https://github.com/graelo/podfeed/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
-          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+          HOMEBREW_NO_ANALYTICS: '1'
+          HOMEBREW_NO_ENV_HINTS: '1'
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          brew bump-formula-pr \
+            --no-browse \
+            --no-fork \
+            --url="${REPO_URL}/archive/refs/tags/${TAG_NAME}.tar.gz" \
+            "${TAP_REPO}/${FORMULA_NAME}"

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          permission-statuses: write
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Apply updates from the `github-actions-playbook` reference repo.

## Summary

### `f831f60` — scoped GitHub App token permissions

- `release.yml` (homebrew job): add `permission-contents: write` and
  `permission-pull-requests: write` to the `create-github-app-token`
  step so the minted token can't act outside the homebrew-tap bump.
- `schedule-renovate.yml`: add `permission-contents: write`,
  `permission-issues: write`, `permission-pull-requests: write`,
  `permission-workflows: write`, `permission-statuses: write` —
  shrinks the App token surface to exactly what Renovate uses.

Addresses the zizmor `github-app` finding (per playbook hardening §5).

### `beb3053` — homebrew brew CLI, prerelease flag, cargo-pants guard

- `_cargo-audit.yml`: replace `cargo install --locked cargo-pants
  || true` with `|| command -v cargo-pants`. `|| true` swallows real
  install failures (network blip, yanked version, build error) and
  surfaces them as a misleading `command not found` on the next line.
  `command -v` tolerates the cache-hit "already installed" case while
  still failing the step when the binary genuinely is not on PATH.
- `release.yml`: publish prerelease tags (containing `-`, e.g. `-rc.1`,
  `-alpha.2`) as GitHub pre-releases via
  `gh release create --prerelease="${IS_PRERELEASE}"`, where
  `IS_PRERELEASE` is the raw `contains(github.ref, '-')` boolean.
  Before, `v1.2.3-rc.1` would have published as "latest".
- `release.yml`: switch the homebrew bump from
  `mislav/bump-homebrew-formula-action` (unmaintained) to Homebrew's
  own `brew bump-formula-pr` CLI. Linuxbrew is preinstalled on
  `ubuntu-latest`; `eval "$(brew shellenv)"` puts it on PATH, then
  `brew tap` + `brew bump-formula-pr --no-browse --no-fork` runs
  end-to-end with no third-party action. `gh auth setup-git` plumbs
  the App token into git's credential helper so the push to the tap
  succeeds. One fewer unverified-creator dependency in the supply
  chain — drops the corresponding `poutine.yml` suppression too.
- `release.yml`: hoist project-specific values (`TAP_REPO`,
  `FORMULA_NAME`, `BOT_NAME`, `BOT_USER_ID`) into the homebrew job's
  `env:` block, and derive `REPO_URL` from `github.server_url` +
  `github.repository` so the archive URL doesn't bake in the project
  name. Substitution points stay obvious when copying this template
  into another repo.
- `release.yml`: move the prerelease skip from a step-level `if:` on
  the bump step to job-level on `homebrew`, so adding more steps later
  doesn't require repeating the condition.

## Test plan

- [ ] CI is green on this branch (ci-essentials, ci-compatibility-matrix,
      ci-security).
- [ ] Manual: cut a `vX.Y.Z-rc.0` tag and verify the GitHub Release is
      published as a pre-release and the homebrew job is skipped.
- [ ] Manual: cut a `vX.Y.Z` tag and verify the homebrew job opens a
      PR on `graelo/homebrew-tap` committed by `graelo-ci-bot[bot]`.